### PR TITLE
「使える文字は半角英数になります。英大文字・小文字・数字を必ず含んでください。」を改行

### DIFF
--- a/picture_book/accounts/validators.py
+++ b/picture_book/accounts/validators.py
@@ -15,6 +15,6 @@ class CustomPasswordValidator:
     
     def get_help_text(self):
         return (
-            '使える文字は半角英数になります。'
+            '使える文字は半角英数になります。\n' #改行コードを入れた状態で値を返す
             '英大文字・小文字・数字を必ず含んでください。'
         )

--- a/picture_book/templates/accounts/registration.html
+++ b/picture_book/templates/accounts/registration.html
@@ -4,7 +4,22 @@
     <h1>新規アカウント登録</h1>
     <form method="POST">
         {% csrf_token %}
-        {{ user_form.as_p }}
+        <!-- {{ user_form.as_p }}は全体を<p>タグで包んで自動生成するのでフィールドに個別の定義ができず改行コードが読み込めない
+          →forで1つずつ読み込むようにする
+        {{ user_form.as_p }} -->
+        {% for field in user_form %}
+        <p>
+            {{ field.label_tag }}<br>
+            {{ field }}<br>
+            {% if field.errors %}
+                <span style="color:red;">{{ field.errors }}</span><br>
+            {% endif %}
+            {% if field.help_text %}
+                <!-- validatators.pyでカスタムしているhelp_textの\nを<br>に変換するためにlinebreaksbrを使用 -->
+                <small style="color:gray;">{{ field.help_text|linebreaksbr }}</small>
+            {% endif %}
+        </p>
+        {% endfor %}
         <input type="submit" value="登録">
     </form>
 </div>


### PR DESCRIPTION
どちらかのパターンで対処可能です。
■パターン1
●registration.html
`<form method="POST">
    {% csrf_token %}
    {{ user_form.as_p }}
    <p>
        {% if user_form.password1.help_text %}
            <small style="color:gray;">{{ user_form.password1.help_text|linebreaksbr }}</small>
        {% endif %}
    </p>
    <input type="submit" value="登録">
</form>
`
validation.py
`
    def get_help_text(self):
        return mark_safe(
            '使える文字は半角英数になります。\n' #改行コードを入れた状態で値を返す
            '英大文字・小文字・数字を必ず含んでください。'
        )
`

■パターン2
validation.py
`
from django.utils.safestring import mark_safe

    def get_help_text(self):
        return mark_safe(
            '使える文字は半角英数になります。<br>英大文字・小文字・数字を必ず含んでください。'
        )
`