### PR TITLE
家族に招待できない問題を修正

### DIFF
--- a/picture_book/accounts/forms.py
+++ b/picture_book/accounts/forms.py
@@ -176,6 +176,8 @@ class FamilyRegistForm(forms.ModelForm):
         user.set_password(self.cleaned_data['password1'])
         if commit:
             user.save()
+            user.family_id = self.family
+            user.save(update_fields=['family_id'])
         return user
 
 User = get_user_model()


### PR DESCRIPTION
GPTそのまま貼り付け↓
----------------------------
🔧「招待リンクから登録したのに、別の家族IDが割り当てられてしまう」問題の解説
🧩【何が起こっていたか？】

ユーザーが招待リンクから登録したとき、本来は「招待した家族（Family）」のIDが割り当てられるはずでした。
しかし、実際には新しい家族IDが自動で新規作成されてしまうという問題が発生していました。
🔍【原因は？】

Django（Webアプリの仕組み）では、ユーザーを登録するときに「マネージャー」という裏側の仕組み（UserManager）が動いています。
この UserManager が、

    「家族IDが空っぽなら、新しく作っちゃえ！」

という動きをしていたため、正しく家族IDが渡っていても、保存時に勝手に上書きされてしまっていたのです。
✅【どうやって修正したか？】

save() という登録処理の中で、次のように2段階で処理を分けました：

    一度、ユーザー情報を保存（この時点では家族IDが意図しないものになっていることがある）

    保存後に、改めて正しい家族IDを上書きして再保存

user.save()  # 一度保存
user.family_id = 招待リンクに含まれていた家族ID
user.save(update_fields=['family_id'])  # 正しい家族IDを明示的に更新

このように、保存後に意図的に正しい家族IDを上書きすることで、元の問題を完全に防ぐことができました。
💡【なぜこの方法が有効だったの？】

Djangoのフォームの保存処理では、内部的に別の関数が呼ばれていて、そこで意図と違う処理（家族IDの自動作成）がされていました。
しかし、一度保存したあとで自分で上書きする処理は Django 側も上書きしないため、完全にコントロールできるようになります。
📌【まとめ】
項目	内容
問題	招待リンクから登録しても、別の家族IDが割り当てられる
原因	Djangoの内部処理で、新しい家族IDが勝手に生成されていた
対処	一度保存したあとに、正しい家族IDを再設定して再保存
ポイント	user.family_id = ... と user.save(update_fields=[...]) の明示的な更新